### PR TITLE
Use new mechanism to disable plugin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,2 @@
-XX.XX.2022: verzion 1.0.0
+XX.XX.2022: version 1.0.0
  * initial release

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
 # Contributors to Antivirus Plugin
 
-- [Jozef Sudolský](https://github.com/azurit)
 - [Max Leske](https://github.com/theseion)
+- [Jozef Sudolský](https://github.com/azurit)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 # Contributors to Antivirus Plugin
 
 - [Jozef Sudolský](https://github.com/azurit)
+- [Max Leske](https://github.com/theseion)

--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ in the official CRS documentation.
 
 ## Configuration
 
-All settings can be done in file `plugins/antivirus-config.conf` which
-must be created by copying or renamig file `plugins/antivirus-config.conf.example`:  
-`cp plugins/antivirus-config.conf.example plugins/antivirus-config.conf`
+All settings can be done in file `plugins/antivirus-config.conf`.
 
 ### Main configuration
 

--- a/plugins/antivirus-before.conf
+++ b/plugins/antivirus-before.conf
@@ -7,6 +7,16 @@
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------
 
+# OWASP CRS Plugin
+# Plugin name: antivirus-plugin
+# Plugin description: Antivirus software support for CRS.
+# Rule ID block base: 9,502,000 - 9,502,999
+# Plugin version: 1.0.0
+
+# Generic rule to disable plugin
+SecRule TX:antivirus-plugin_enabled "@eq 0" "id:9502099,phase:1,pass,nolog,ctl:ruleRemoveById=9502100-9502999"
+
+
 SecRule TX:ANTIVIRUS-PLUGIN_SCAN_UPLOADED_FILE "@eq 1" \
     "id:9502110,\
     phase:2,\

--- a/plugins/antivirus-config.conf
+++ b/plugins/antivirus-config.conf
@@ -16,8 +16,34 @@
 # Documentation can be found here:
 # https://github.com/coreruleset/antivirus-plugin
 
+# Generic rule to disable the plugin
+#
+# Plugins are enabled by default.
+#
+# They become active by placing them in the plugin folder. It is possible to
+# control plugin activation via setting a variable. This can be done in the
+# plugin config file here.
+#
+# The predefined variable name is meant to be "<plugin name>-plugin_enabled".
+# For the antivirus-plugin, this means it can be disabled by setting
+# tx.antivirus-plugin_enabled=0.
+#
+# Note that a global setting of this variable overrides the setting here.
+# That means the "enabled" variable is only set by this rule if it has not
+# been set before.
+#
+# Feel free to set the variable unconditionally here by replacing the
+# SecRule line with an unconditional SecAction statement.
+#
+#SecRule &TX:antivirus-plugin_enabled "@eq 0" \
+#  "id:9502010,\
+#   phase:1,\
+#   pass,\
+#   nolog,\
+#   setvar:'tx.antivirus-plugin_enabled=0'"
+
 SecAction \
- "id:9502010,\
+ "id:9502020,\
   phase:1,\
   nolog,\
   pass,\


### PR DESCRIPTION
Plugins are enabled by default, so the '.example' config has been renamed to be in line with the other plugins

Updated readme